### PR TITLE
Remove print statement from run_pr function.

### DIFF
--- a/mindflow/core/git/pr.py
+++ b/mindflow/core/git/pr.py
@@ -15,7 +15,6 @@ from mindflow.utils.prompts import PR_TITLE_PREFIX
 def run_pr(args: Tuple[str], title: Optional[str] = None, body: Optional[str] = None):
     base_branch = get_flag_value(args, ["--base", "-B"])
 
-    print("is this working?")
     if base_branch is None:
         # Determine the name of the default branch
         base_branch = (


### PR DESCRIPTION
This pull request removes a print statement from the `run_pr` function in the `pr.py` file. The change was made to improve the code's cleanliness and remove unnecessary output.